### PR TITLE
Use a hashed package set

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ PureScript.
 [bazel-getting-started]: https://docs.bazel.build/versions/master/getting-started.html
 [nix]: https://nixos.org/nix
 [psc-package]: https://psc-package.readthedocs.io/en/latest/
+[psc-prefetch]: https://github.com/heyhabito/psc-prefetch/
 
 ## Requirements
 
@@ -125,11 +126,13 @@ register_toolchains("//:purescript")
 
 ## Configuring a packageset
 
-`rules_purescript` supports generating Bazel definitions for PureScript
-packagesets (as specified by [psc-package][psc-package]). Currently you can do
-this using:
+`rules_purescript` supports generating Bazel definitions for *a modified* version of PureScript
+packagesets (as specified by [psc-package][psc-package]), with a `sha256` field added to each package.
 
-* Nix
+### Psc-Prefetch
+In order for Nix to verify the downloaded package is correct it needs a hash for each package.
+This hash is checked against `nix-hash <directory> --type sha256 --base32` where directory is a checkout of the `repo` at the specified `version` (with submodules) with the `.git` directory removed.
+[Psc-Prefetch][psc-prefetch] is a tool that can enrich a given package set with the necessary hashes. 
 
 ### Using Nix
 
@@ -163,7 +166,7 @@ purescript_import_packages(
 
 The `nix_file` argument specifies a `.nix` file in the repository providing an
 expression representing a function from a Bazel context to a Nix set with a
-PureScript packageset in the attribute named by `base_attribute_path`:
+PureScript packageset (with hashes) in the attribute named by `base_attribute_path`:
 
 `nix/purescript-packages.nix`:
 
@@ -178,8 +181,8 @@ let
 
   packagesJSON =
     builtins.fromJSON (builtins.readFile (builtins.fetchurl {
-      url = "https://raw.githubusercontent.com/purescript/package-sets/psc-0.12.1/packages.json";
-      sha256 = "0iy336bgz36snkxmrb4li6b9nnv0x4dx9gbcvnw5r2q9hzlx0zvj";
+      url = "https://raw.githubusercontent.com/heyhabito/package-sets/master/packages-with-sha256.json";
+      sha256 = "0km8pnvn5wlprwc18bw9vng47dang1hp8x24k73njc50l3fi6rhh";
     }));
 
 in {

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -1,4 +1,4 @@
 import (fetchTarball {
   # Nixpkgs checkout from 2018-11-03.
-  url = "https://github.com/NixOS/nixpkgs/archive/01389f1ad6ecb894d2f20f390d944b1e70674a9e.tar.gz";
+  url = "https://github.com/NixOS/nixpkgs/archive/84b7bf85f45b658f956a607f0c1901fdae1cbfdb.tar.gz";
 })

--- a/nix/purescript-packages.nix
+++ b/nix/purescript-packages.nix
@@ -8,8 +8,8 @@ let
 
   packagesJSON =
     builtins.fromJSON (builtins.readFile (builtins.fetchurl {
-      url = "https://raw.githubusercontent.com/purescript/package-sets/psc-0.12.1/packages.json";
-      sha256 = "0iy336bgz36snkxmrb4li6b9nnv0x4dx9gbcvnw5r2q9hzlx0zvj";
+      url = "https://raw.githubusercontent.com/heyhabito/psc-packages-with-checksum/master/packages.json";
+      sha256 = "1xdfgfm1mvx8xwjarrc3chc3byf0gnrm80k4qyl074f2hy9mwxzn";
     }));
 
 in {

--- a/purescript/nix/default.nix
+++ b/purescript/nix/default.nix
@@ -17,68 +17,50 @@ let
       packageBuilds =
         lib.attrsets.mapAttrs
           (name: spec:
-            let
-              prefetch =
-                builtins.fromJSON (builtins.readFile (runCommand "prefetch-${name}"
-                  {
-                    SSL_CERT_FILE = "${cacert.out}/etc/ssl/certs/ca-bundle.crt";
-                    buildInputs = [
-                      nix-prefetch-git
-                    ];
-                  }
-                  ''
-                    nix-prefetch-git \
-                      --quiet \
-                      --fetch-submodules \
-                      --url ${spec.repo} \
-                      --rev ${spec.version} > $out
-                  ''));
+            stdenv.mkDerivation {
+              name = name;
+              version = spec.version;
+              src = fetchgit {
+                url = spec.repo;
+                rev = spec.version;
+                sha256 = spec.sha256;
+              };
+              phases = "installPhase";
+              installPhase = ''
+                mkdir -p $out/src
+                cp -r $src/src/. $out/src
 
-            in
-              stdenv.mkDerivation {
-                name = name;
-                version = spec.version;
-                src = fetchgit {
-                  url = spec.repo;
-                  rev = prefetch.rev;
-                  sha256 = prefetch.sha256;
-                };
-                phases = "installPhase";
-                installPhase = ''
-                  mkdir -p $out/src
-                  cp -r $src/src/. $out/src
+                cat > $out/BUILD.bzl <<EOF
+                load(
+                    "@com_habito_rules_purescript//purescript:purescript.bzl",
+                    "purescript_library",
+                )
 
-                  cat > $out/BUILD.bzl <<EOF
-                  load(
-                      "@com_habito_rules_purescript//purescript:purescript.bzl",
-                      "purescript_library",
-                  )
+                DEPS = ${"[" +
+                  lib.strings.concatMapStringsSep "," (d: "\"" + d + "\"")
+                    spec.dependencies + "]"}
 
-                  DEPS = ${"[" +
-                    lib.strings.concatMapStringsSep "," (d: "\"" + d + "\"")
-                      spec.dependencies + "]"}
+                def targets():
+                    purescript_library(
+                        name = "pkg",
+                        src_strip_prefix = "src",
+                        srcs = native.glob(["src/**/*.purs"]),
+                        foreign_srcs = native.glob(["src/**/*.js"]),
+                        deps = ["@${ctx.attr.packageset_name}-package-" + dep + "//:pkg" for dep in DEPS],
+                        visibility = ["//visibility:public"],
+                    )
 
-                  def targets():
-                      purescript_library(
-                          name = "pkg",
-                          src_strip_prefix = "src",
-                          srcs = native.glob(["src/**/*.purs"]),
-                          foreign_srcs = native.glob(["src/**/*.js"]),
-                          deps = ["@${ctx.attr.packageset_name}-package-" + dep + "//:pkg" for dep in DEPS],
-                          visibility = ["//visibility:public"],
-                      )
-
-                      native.filegroup(
-                          name = "purs",
-                          srcs = native.glob(["src/**/*.purs"]) + [
-                              "@${ctx.attr.packageset_name}-package-" +
-                                  dep + "//:purs" for dep in DEPS
-                          ],
-                          visibility = ["//visibility:public"],
-                      )
-                  EOF
-                '';
-              }
+                    native.filegroup(
+                        name = "purs",
+                        srcs = native.glob(["src/**/*.purs"]) + [
+                            "@${ctx.attr.packageset_name}-package-" +
+                                dep + "//:purs" for dep in DEPS
+                        ],
+                        visibility = ["//visibility:public"],
+                    )
+                EOF
+              '';
+            }
           )
           packagesJSON;
 

--- a/purescript/nix/default.nix
+++ b/purescript/nix/default.nix
@@ -5,7 +5,6 @@
 
   cacert,
   fetchgit,
-  nix-prefetch-git,
   stdenv,
 
   ctx


### PR DESCRIPTION
The rules are now able to work from a package set where the hashes have been pre-calculated.