### PR TITLE
Fix tests for purescript_library targets

### DIFF
--- a/nix/purescript-packages.nix
+++ b/nix/purescript-packages.nix
@@ -8,8 +8,8 @@ let
 
   packagesJSON =
     builtins.fromJSON (builtins.readFile (builtins.fetchurl {
-      url = "https://raw.githubusercontent.com/heyhabito/psc-packages-with-checksum/master/packages.json";
-      sha256 = "1xdfgfm1mvx8xwjarrc3chc3byf0gnrm80k4qyl074f2hy9mwxzn";
+      url = "https://raw.githubusercontent.com/heyhabito/package-sets/master/packages-with-sha256.json";
+      sha256 = "0km8pnvn5wlprwc18bw9vng47dang1hp8x24k73njc50l3fi6rhh";
     }));
 
 in {

--- a/purescript/compile.bzl
+++ b/purescript/compile.bzl
@@ -29,12 +29,10 @@ load(
     "@bazel_skylib//lib:paths.bzl",
     "paths",
 )
-
 load(
     "@bazel_skylib//lib:shell.bzl",
     "shell",
 )
-
 load(
     ":context.bzl",
     "purescript_context",
@@ -174,7 +172,7 @@ def _purescript_bundle_impl(ctx):
     return [
         PureScriptBundleInfo(
             bundle = bundle,
-        )
+        ),
     ]
 
 purescript_bundle = rule(
@@ -189,7 +187,6 @@ Build a bundle from PureScript sources.
         "foreign_srcs": _ATTRS.foreign_srcs,
         "src_strip_prefix": _ATTRS.src_strip_prefix,
         "deps": _ATTRS.deps,
-
         "_repl_template": _ATTRS._repl_template,
     },
     outputs = {
@@ -249,7 +246,7 @@ def _purescript_library_impl(ctx):
 
     return [
         DefaultInfo(
-            files = depset(transitive = [ctx_p.srcs, ctx_p.foreign_srcs]),
+            files = depset(transitive = [ctx_p.srcs, ctx_p.foreign_srcs, depset([ctx.outputs.package, ctx.outputs.repl])]),
         ),
         PureScriptLibraryInfo(
             package = package,
@@ -257,7 +254,7 @@ def _purescript_library_impl(ctx):
             foreign_srcs = ctx_p.foreign_srcs,
             transitive_srcs = ctx_p.transitive_srcs,
             transitive_foreign_srcs = ctx_p.transitive_foreign_srcs,
-        )
+        ),
     ]
 
 def _purescript_build_library(
@@ -273,7 +270,7 @@ def _purescript_build_library(
     repl):
 
     if ps.psci_support:
-        psci_support_files = " ".join([f.path for f in ps.psci_support.files])
+        psci_support_files = " ".join([f.path for f in ps.psci_support.files.to_list()])
     else:
         psci_support_files = ""
 
@@ -290,7 +287,7 @@ def _purescript_build_library(
     ctx.actions.run_shell(
         mnemonic = mnemonic,
         progress_message = progress_message,
-        inputs = ctx_p.transitive_srcs + ctx_p.transitive_foreign_srcs,
+        inputs = depset(transitive = [ctx_p.transitive_srcs, ctx_p.transitive_foreign_srcs]),
         outputs = [package],
         tools = [
             purs,
@@ -383,7 +380,6 @@ Build a library from PureScript sources.
         "foreign_srcs": _ATTRS.foreign_srcs,
         "src_strip_prefix": _ATTRS.src_strip_prefix,
         "deps": _ATTRS.deps,
-
         "_repl_template": _ATTRS._repl_template,
     },
     outputs = {

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -29,6 +29,7 @@ rule_test(
     name = "test-library-simple",
     size = "small",
     generates = [
+        "LibSimple.purs",
         "library-simple.purs-package",
         "library-simple@repl",
     ],
@@ -39,6 +40,7 @@ rule_test(
     name = "test-library-dependencies",
     size = "small",
     generates = [
+        "LibDeps.purs",
         "library-dependencies.purs-package",
         "library-dependencies@repl",
     ],
@@ -51,6 +53,7 @@ rule_test(
     generates = [
         "library-prefix.purs-package",
         "library-prefix@repl",
+        "src/LibPrefix.purs",
     ],
     rule = "//tests/library-prefix",
 )
@@ -60,7 +63,8 @@ rule_test(
     size = "small",
     generates = [
         "library-transitive.purs-package",
-        "library-transitive@repl"
+        "library-transitive@repl",
+        "src/LibTrans.purs",
     ],
     rule = "//tests/library-transitive",
 )
@@ -70,7 +74,9 @@ rule_test(
     size = "small",
     generates = [
         "library-foreign.purs-package",
-        "library-foreign@repl"
+        "library-foreign@repl",
+        "src/LibForeign.js",
+        "src/LibForeign.purs",
     ],
     rule = "//tests/library-foreign",
 )


### PR DESCRIPTION
The DefaultInfo declaration hid the purs-package files.
Depsets are not iterable anymore (added to_list()).
The packageset URL was invalid and did not match the README.